### PR TITLE
GRBK-1450 Exclude transisitive dependency tika-parser => cxf-rt-rs-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
 *.class
+.idea
+.project
+.classpath
+.settings
+*.iml
+*.swp
+*.orig
+*.rej
+.DS_Store
+.metadata
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -174,7 +174,7 @@
 			<version>1.1</version>
 			<type>jar</type>
 			<scope>compile</scope>
-		</dependency>
+		</dependency> 
 		
 		<dependency>
 			<groupId>org.apache.tika</groupId>
@@ -192,6 +192,12 @@
 			<artifactId>tika-parsers</artifactId>
 			<version>1.2</version>
 			<scope>compile</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.cxf</groupId>
+					<artifactId>cxf-rt-rs-client</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
cxf was bringing in javax.ws.rs-api-2.0.1.jar which does not play well
with jersey 1.x
